### PR TITLE
Fix constraint bug

### DIFF
--- a/plonk-intro-cn/7-plonk-lookup.md
+++ b/plonk-intro-cn/7-plonk-lookup.md
@@ -263,7 +263,7 @@ $$
 $$
 \begin{split}
 L_0(X)\cdot(z(X)-1) & = 0 \\
-L_{N-1}(X)\cdot(s^{lo}(X)-s^{hi}(X)) & = 0 \\
+L_{N-1}(X)\cdot(s^{lo}(X)-s^{hi}(\omega\cdot X)) & = 0 \\
 L_{N-1}(X)\cdot(z(X)-1) & = 0\\
 \end{split}
 $$


### PR DESCRIPTION
To constrain the last element of $S^{lo}$ equals to the first element of $S^{hi}$, if choose $L_{N-1}(X)$ as the lagrange polynomial, then $S^{hi}$ should shift to next element by times $\omega$ and get the first element of $S^{hi}$, so the equation holds